### PR TITLE
Close requests to avoid excessive TIME_WAIT

### DIFF
--- a/Payload_Type/medusa/agent_code/base_agent/base_agent.py2
+++ b/Payload_Type/medusa/agent_code/base_agent/base_agent.py2
@@ -159,6 +159,9 @@ CRYPTO_HERE
             urllib2.install_opener(opener)
         try:
             out = base64.b64decode(urllib2.urlopen(req).read())
+            response = urllib2.urlopen(req)
+            out = base64.b64decode(response.read())
+            response.close()
             return out.decode() if method == 'GET' else out
         except: return ""
 

--- a/Payload_Type/medusa/agent_code/base_agent/base_agent.py2
+++ b/Payload_Type/medusa/agent_code/base_agent/base_agent.py2
@@ -158,7 +158,6 @@ CRYPTO_HERE
                 opener = urllib2.build_opener(proxy, handler)
             urllib2.install_opener(opener)
         try:
-            out = base64.b64decode(urllib2.urlopen(req).read())
             response = urllib2.urlopen(req)
             out = base64.b64decode(response.read())
             response.close()

--- a/Payload_Type/medusa/agent_code/base_agent/base_agent.py3
+++ b/Payload_Type/medusa/agent_code/base_agent/base_agent.py3
@@ -159,6 +159,7 @@ CRYPTO_HERE
         try:
             with urllib.request.urlopen(req) as response:
                 out = base64.b64decode(response.read())
+                response.close()
                 return out.decode() if method == 'GET' else out 
         except: return ""
 


### PR DESCRIPTION
This should prevent an excess number of TIME_WAIT’s in the netstat from not properly closing requests. 

@deviousbanana contributed to this code and testing for this PR as well. 