### PR TITLE
Add compile checks for agent code modules

### DIFF
--- a/.github/workflows/payload-build-matrix.yml
+++ b/.github/workflows/payload-build-matrix.yml
@@ -28,13 +28,24 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Python ${{ matrix.python-version }}
+        if: matrix.python-version != '2.7'
         uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
 
+      - name: Install Python 2.7
+        if: matrix.python-version == '2.7'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y python2
+
       - name: Run agent_code syntax smoke tests
         run: |
-          python tests/test_agent_code_syntax.py -v
+          if [ "${{ matrix.python-version }}" = "2.7" ]; then
+            python2 tests/test_agent_code_syntax.py -v
+          else
+            python tests/test_agent_code_syntax.py -v
+          fi
 
   discover-combos:
     runs-on: ubuntu-latest

--- a/.github/workflows/payload-build-matrix.yml
+++ b/.github/workflows/payload-build-matrix.yml
@@ -16,6 +16,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  agent-code-syntax:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["2.7", "3.11"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: "${{ matrix.python-version }}"
+
+      - name: Run agent_code syntax smoke tests
+        run: |
+          python tests/test_agent_code_syntax.py -v
+
   discover-combos:
     runs-on: ubuntu-latest
     outputs:

--- a/Payload_Type/medusa/medusa/agent_code/vscode_open_edits.py
+++ b/Payload_Type/medusa/medusa/agent_code/vscode_open_edits.py
@@ -26,7 +26,7 @@
                         else:
                             open_edit["backup"] = path
                             open_edit["original"] = file_content[0].split("{")[0].replace("file://","").rstrip()
-                            open_edit["size"] = f"{json_data['size']} B"
+                            open_edit["size"] = "{} B".format(json_data['size'])
                             open_edit["mtime"] = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(json_data["mtime"]/1000))
                             open_edit["ctime"] = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(json_data["ctime"]/1000))
                             open_edit["type"] = "Edit"

--- a/tests/test_agent_code_syntax.py
+++ b/tests/test_agent_code_syntax.py
@@ -1,10 +1,10 @@
-import pathlib
+import os
 import sys
 import unittest
 
 
-ROOT = pathlib.Path(__file__).resolve().parents[1]
-AGENT_CODE_PATH = ROOT / "Payload_Type" / "medusa" / "medusa" / "agent_code"
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+AGENT_CODE_PATH = os.path.join(ROOT, "Payload_Type", "medusa", "medusa", "agent_code")
 
 # Each agent_code command file is a class-method fragment (an indented `def`
 # meant to be spliced into the agent class at build time), so wrapping it in a
@@ -23,21 +23,29 @@ else:
 
 def discover_command_fragments(suffixes):
     fragments = []
-    for path in sorted(AGENT_CODE_PATH.glob("*")):
-        if path.is_file() and path.name.rsplit(".", 1)[-1] in suffixes:
+    for name in sorted(os.listdir(AGENT_CODE_PATH)):
+        path = os.path.join(AGENT_CODE_PATH, name)
+        if os.path.isfile(path) and name.rsplit(".", 1)[-1] in suffixes:
             fragments.append(path)
     return fragments
 
 
-def _make_compile_test(fragment):
-    def test(self):
-        wrapped = CLASS_WRAPPER + fragment.read_text()
-        try:
-            compile(wrapped, fragment.name, "exec")
-        except SyntaxError as e:
-            self.fail("Syntax error in {}: {}".format(fragment.name, e))
+def _read_file(path):
+    with open(path, "r") as f:
+        return f.read()
 
-    test.__doc__ = "syntax check: {}".format(fragment.name)
+
+def _make_compile_test(fragment):
+    fragment_name = os.path.basename(fragment)
+
+    def test(self):
+        wrapped = CLASS_WRAPPER + _read_file(fragment)
+        try:
+            compile(wrapped, fragment_name, "exec")
+        except SyntaxError as e:
+            self.fail("Syntax error in {}: {}".format(fragment_name, e))
+
+    test.__doc__ = "syntax check: {}".format(fragment_name)
     return test
 
 
@@ -51,7 +59,7 @@ def _attach_fragment_tests():
     # Generate one test method per fragment so each file shows up as its own
     # result line in verbose/debug output (e.g. test_cat_py, test_ls_py3).
     for fragment in discover_command_fragments(FRAGMENT_SUFFIXES):
-        name = "test_" + fragment.name.replace(".", "_")
+        name = "test_" + os.path.basename(fragment).replace(".", "_")
         setattr(TestAgentCodeSyntax, name, _make_compile_test(fragment))
 
 

--- a/tests/test_agent_code_syntax.py
+++ b/tests/test_agent_code_syntax.py
@@ -1,0 +1,62 @@
+import pathlib
+import sys
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+AGENT_CODE_PATH = ROOT / "Payload_Type" / "medusa" / "medusa" / "agent_code"
+
+# Each agent_code command file is a class-method fragment (an indented `def`
+# meant to be spliced into the agent class at build time), so wrapping it in a
+# throwaway class body makes it a syntactically valid module for compilation.
+CLASS_WRAPPER = "class _SyntaxCheck(object):\n"
+
+# `.py` files are python-version agnostic and compile under either interpreter.
+# `.py2`/`.py3` files are validated only by their matching interpreter, since
+# each may contain syntax the other version cannot parse. CI runs this test
+# under both Python 2 and Python 3 to cover every fragment.
+if sys.version_info[0] == 2:
+    FRAGMENT_SUFFIXES = ("py", "py2")
+else:
+    FRAGMENT_SUFFIXES = ("py", "py3")
+
+
+def discover_command_fragments(suffixes):
+    fragments = []
+    for path in sorted(AGENT_CODE_PATH.glob("*")):
+        if path.is_file() and path.name.rsplit(".", 1)[-1] in suffixes:
+            fragments.append(path)
+    return fragments
+
+
+def _make_compile_test(fragment):
+    def test(self):
+        wrapped = CLASS_WRAPPER + fragment.read_text()
+        try:
+            compile(wrapped, fragment.name, "exec")
+        except SyntaxError as e:
+            self.fail("Syntax error in {}: {}".format(fragment.name, e))
+
+    test.__doc__ = "syntax check: {}".format(fragment.name)
+    return test
+
+
+class TestAgentCodeSyntax(unittest.TestCase):
+    def test_command_fragments_discovered(self):
+        fragments = discover_command_fragments(FRAGMENT_SUFFIXES)
+        self.assertTrue(fragments, "No agent_code command fragments were discovered")
+
+
+def _attach_fragment_tests():
+    # Generate one test method per fragment so each file shows up as its own
+    # result line in verbose/debug output (e.g. test_cat_py, test_ls_py3).
+    for fragment in discover_command_fragments(FRAGMENT_SUFFIXES):
+        name = "test_" + fragment.name.replace(".", "_")
+        setattr(TestAgentCodeSyntax, name, _make_compile_test(fragment))
+
+
+_attach_fragment_tests()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request introduces automated syntax checking for all agent code command fragments and makes a minor code style update. The main focus is on ensuring that every agent code fragment is syntactically valid under both Python 2 and Python 3, with CI integration to catch syntax errors early.

### Continuous Integration Improvements

* Added a new `agent-code-syntax` job to the GitHub Actions workflow (`.github/workflows/payload-build-matrix.yml`) that runs a syntax smoke test on agent code fragments for both Python 2.7 and Python 3.11. This ensures compatibility and catches syntax errors across both interpreters.

### Testing Enhancements

* Introduced `tests/test_agent_code_syntax.py`, which dynamically discovers all agent code command fragments and verifies their syntax by compiling them within a dummy class. The test runs under both Python 2 and Python 3, and generates individual test cases for each fragment for clearer CI output.

### Code Style

* Updated string formatting in `Payload_Type/medusa/medusa/agent_code/vscode_open_edits.py` to use `str.format()` instead of f-strings, improving compatibility with Python 2.